### PR TITLE
Add initial support for preflight requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ arguments, and return a three-tuple of the from `{Value, Req, State}`.
 | cors_allowed_origins   | `[]`                      |
 | cors_allow_credentials | `false`                   |
 | cors_exposed_headers   | `[]`                      |
+| cors_allowed_headers   | `[]`                      |
+| cors_allowed_methods   | `[]`                      |
 
 # Todo
-
-* Support for preflight requests.
 
 * Allow wildcard response for `cors_allowed_credentials`.
 

--- a/src/cowboy_cors.erl
+++ b/src/cowboy_cors.erl
@@ -10,12 +10,14 @@
 -export([execute/2]).
 
 -record(state, {
-          env :: cowboy_middleware:env(),
-          origin :: binary(),
+          env                  :: cowboy_middleware:env(),
+          origin               :: binary(),
+          request_method       :: binary(),
+          request_headers = [] :: [binary()],
 
           %% Policy handler.
-          policy :: atom(),
-          policy_state :: any()
+          policy               :: atom(),
+          policy_state         :: any()
 }).
 
 %% @private
@@ -55,13 +57,111 @@ allowed_origins(Req, State = #state{origin = Origin}) ->
         {List, Req1, PolicyState} ->
             case lists:member(Origin, List) of
                 true ->
-                    allow_credentials(Req1, State#state{policy_state = PolicyState});
+                    %% both models are identical prior to this point
+                    choose_processing_model(Req1, State#state{policy_state = PolicyState});
                 false ->
                     terminate(Req, State#state{policy_state = PolicyState})
             end
     end.
 
-%% allow_credentials/2 should return true or false.
+%% select either simple or preflight request processing model
+choose_processing_model(Req, State) ->
+    case cowboy_req:method(Req) of
+        {<<"OPTIONS">>, Req1} ->
+            preflight_model(Req1, State);
+        {_Method, Req1} ->
+            simple_model(Req1, State)
+    end.
+
+preflight_model(Req, State) ->
+    request_method(Req, State).
+
+simple_model(Req, State) ->
+    {Req1, State1} = allow_credentials(Req, State),
+    exposed_headers(Req1, State1).
+
+request_method(Req, State) ->
+    case cowboy_req:header(<<"access-control-request-method">>, Req) of
+        {undefined, Req1} ->
+            terminate(Req1, State);
+        {Data, Req1} ->
+            cowboy_http:token(Data,
+                              fun(<<>>, Method) ->
+                                      request_headers(Req1, State#state{request_method = Method});
+                                 (_, _) ->
+                                      terminate(Req1, State)
+                              end)
+    end.
+
+request_headers(Req, State) ->
+    {Headers, Req1} = cowboy_req:header(<<"access-control-request-headers">>, Req, <<>>),
+    case cowboy_http:list(Headers, fun cowboy_http:token_ci/2) of
+        {error, badarg} ->
+            terminate(Req1, State);
+        List ->
+            allowed_methods(Req1, State#state{request_headers = List})
+    end.
+
+%% allow_methods/2 should return a list of binary method names
+allowed_methods(Req, State = #state{request_method = Method}) ->
+    case call(Req, State, cors_allowed_methods) of
+        no_call ->
+            terminate(Req, State);
+        {List, Req1, PolicyState} ->
+            case lists:member(Method, List) of
+                false ->
+                    terminate(Req1, State#state{policy_state = PolicyState});
+                true ->
+                    allowed_headers(Req1, State#state{policy_state = PolicyState})
+            end
+    end.
+
+allowed_headers(Req, State = #state{request_headers = Requested}) ->
+    case call(Req, State, cors_allowed_headers) of
+        no_call ->
+            check_allowed_headers(Requested, [], Req, State);
+        {List, Req1, PolicyState} ->
+            check_allowed_headers(Requested, List, Req1, State#state{policy_state = PolicyState})
+    end.
+
+check_allowed_headers([], _, Req, State) ->
+    set_preflight_headers(Req, State);
+check_allowed_headers(_, [], Req, State) ->
+    terminate(Req, State);
+check_allowed_headers([<<"origin">>|Tail], Allowed, Req, State) ->
+    %% KLUDGE: for browsers that include this header, but don't
+    %% actually check it (i.e. Webkit).  Given that the 'Origin'
+    %% header underpins the entire CORS framework, its inclusion in
+    %% the requested headers is nonsensical.
+    check_allowed_headers(Tail, Allowed, Req, State);
+check_allowed_headers([Header|Tail], Allowed, Req, State) ->
+    case lists:member(Header, Allowed) of
+        false ->
+            terminate(Req, State);
+        true ->
+            check_allowed_headers(Tail, Allowed, Req, State)
+    end.
+
+set_preflight_headers(Req, State) ->
+    {Req1, State1} = allow_credentials(Req, State),
+    set_allow_methods(Req1, State1).
+
+set_allow_methods(Req, State = #state{request_method = Method}) ->
+    Req1 = cowboy_req:set_resp_header(<<"access-control-allow-methods">>, Method, Req),
+    set_allow_headers(Req1, State).
+
+set_allow_headers(Req, State) ->
+    %% Since we have already validated the requested headers, we can
+    %% simply reflect the list back to the client.
+    case cowboy_req:header(<<"access-control-request-headers">>, Req) of
+        {undefined, Req1} ->
+            terminate(Req1, State);
+        {Headers, Req1} ->
+            Req2 = cowboy_req:set_resp_header(<<"access-control-allow-headers">>, Headers, Req1),
+            terminate(Req2, State)
+    end.
+
+%% allow_credentials/1 should return true or false.
 allow_credentials(Req, State) ->
     expect(Req, State, cors_allow_credentials, false,
            fun if_not_allow_credentials/2, fun if_allow_credentials/2).
@@ -72,12 +172,12 @@ if_allow_credentials(Req, State = #state{origin = Origin}) ->
     Req1 = cowboy_req:set_resp_header(<<"access-control-allow-origin">>, Origin, Req),
     Req2 = cowboy_req:set_resp_header(<<"access-control-allow-credentials">>, <<"true">>, Req1),
     Req3 = cowboy_req:set_resp_header(<<"vary">>, <<"origin">>, Req2),
-    exposed_headers(Req3, State).
+    {Req3, State}.
 
 if_not_allow_credentials(Req, State = #state{origin = Origin}) ->
     Req1 = cowboy_req:set_resp_header(<<"access-control-allow-origin">>, Origin, Req),
     Req2 = cowboy_req:set_resp_header(<<"vary">>, <<"origin">>, Req1),
-    exposed_headers(Req2, State).
+    {Req2, State}.
 
 %% exposed_headers/2 should return a list of binary header names.
 exposed_headers(Req, State) ->


### PR DESCRIPTION
This follows the steps in section 6.2 of the specification.  Steps 1
and 2 of both section 6.1 and 6.2 have been combined as intial sanity
checking steps before selecting a processing model.
