### PR TITLE
Allow for wildcard value for `allowed_origins/2` callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ arguments, and return a three-tuple of the from `{Value, Req, State}`.
 
 # Todo
 
-* Allow wildcard response for `allowed_credentials`.
 
 * Provide callback to set the `Access-Control-Max-Age` header.
-
 * Allow individual handlers to provide policy, rather than just a
   global policy.

--- a/test/cors_SUITE_data/cors_policy.erl
+++ b/test/cors_SUITE_data/cors_policy.erl
@@ -12,8 +12,12 @@ policy_init(Req) ->
     {ok, Req, undefined_state}.
 
 allowed_origins(Req, State) ->
-    {Allowed, Req1} = parse_list(<<"allowed_origins">>, Req),
-    {Allowed, Req1, State}.
+    case parse_list(<<"allowed_origins">>, Req) of
+        {[<<"*">>], Req1} ->
+            {'*', Req1, State};
+        {Allowed, Req1} ->
+            {Allowed, Req1, State}
+    end.
 
 allow_credentials(Req, State) ->
     {IsAllowed, Req1} = parse_boolean(<<"allow_credentials">>, Req, false),


### PR DESCRIPTION
The callback can now return the atom '*' in order to indicate that any
origin is acceptable.  This provides a simple mechanism for allowing
CORS requests from any Origin.

Due to the requirement that "*" cannot be returned when credentials
are allowed, we simply only ever set Access-Control-Allowed-Origins to
be the Origin of the client.  Unless there are any surprises with
client implementations, this should sufficiently cover the necessary
use cases.
