### PR TITLE
Add `max_age/2` callback for cross-origin policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ arguments, and return a three-tuple of the from `{Value, Req, State}`.
 | exposed_headers        | `[]`                      |
 | allowed_headers        | `[]`                      |
 | allowed_methods        | `[]`                      |
+| max_age                | `undefined`               |
 
 # Todo
 
 
-* Provide callback to set the `Access-Control-Max-Age` header.
 * Allow individual handlers to provide policy, rather than just a
   global policy.

--- a/test/cors_SUITE_data/cors_policy.erl
+++ b/test/cors_SUITE_data/cors_policy.erl
@@ -7,6 +7,7 @@
 -export([exposed_headers/2]).
 -export([allowed_headers/2]).
 -export([allowed_methods/2]).
+-export([max_age/2]).
 
 policy_init(Req) ->
     {ok, Req, undefined_state}.
@@ -35,6 +36,10 @@ allowed_methods(Req, State) ->
     {Allowed, Req1} = parse_list(<<"allowed_methods">>, Req),
     {Allowed, Req1, State}.
 
+max_age(Req, State) ->
+    {MaxAge, Req1} = parse_integer(<<"max_age">>, Req),
+    {MaxAge, Req1, State}.
+
 parse_list(Name, Req) ->
     case cowboy_req:qs_val(Name, Req) of
         {undefined, Req1} ->
@@ -52,4 +57,14 @@ parse_boolean(Name, Req, Default) ->
             {true, Req1};
         {<<"false">>, Req1} ->
             {false, Req1}
+    end.
+
+parse_integer(Name, Req) ->
+    case cowboy_req:qs_val(Name, Req) of
+        {undefined, Req1} ->
+            {undefined, Req1};
+        {Bin, Req1} ->
+            String = binary_to_list(Bin),
+            {MaxAge, []} = string:to_integer(String),
+            {MaxAge, Req1}
     end.


### PR DESCRIPTION
This allows the `Access-Control-Max-Age` header to be set in the
response to a preflight request.  The return value of this callback
must be a non-negative integer or 'undefined'.
