### PR TITLE
Added extra check_allowed_headers kludge for Accept request header

### DIFF
--- a/src/cowboy_cors.erl
+++ b/src/cowboy_cors.erl
@@ -125,6 +125,9 @@ check_allowed_headers([<<"origin">>|Tail], Allowed, Req, State) ->
     %% header underpins the entire CORS framework, its inclusion in
     %% the requested headers is nonsensical.
     check_allowed_headers(Tail, Allowed, Req, State);
+check_allowed_headers([<<"accept">>|Tail], Allowed, Req, State) ->
+    %% KLUDGE: for browsers that include this header.
+    check_allowed_headers(Tail, Allowed, Req, State);
 check_allowed_headers([Header|Tail], Allowed, Req, State) ->
     case lists:member(Header, Allowed) of
         false ->


### PR DESCRIPTION
Chrome adds an "accept" value to the Access-Control-Request-Headers request header.  This was causing termination of the request.

I've added a kludge/check for this (same as the "origin" kludge/check) to cowboy_cors:check_allowed_headers/4.

Thanks

Ivan

p.s. Thanks v much for cowboy_cors!
